### PR TITLE
Fix default double-tap behavior for knobs and handle orientation changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity android:name=".Settings.SettingsActivity" />
-        <activity android:name=".Activity.MainActivity">
+        <activity android:name=".Activity.MainActivity"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/teamdarkness/godlytorch/Fragment/SingleKnobFragment.kt
+++ b/app/src/main/java/com/teamdarkness/godlytorch/Fragment/SingleKnobFragment.kt
@@ -68,7 +68,7 @@ class SingleKnobFragment : Fragment(), OnFragmentBackPressListener {
             // get torch file location
             singleLedFileLocation = prefs.getString(Constrains.PREF_SINGLE_FILE_LOCATION, null)
 
-            doubleTapEnabled = prefs.getBoolean(Constrains.PREF_DOUBLE_TONE_ENABLED, false)
+            doubleTapEnabled = prefs.getBoolean(Constrains.PREF_DOUBLE_TONE_ENABLED, true)
 
             // get max brightness
             brightnessMax = prefs.getInt("brightnessMax", 0)

--- a/app/src/main/java/com/teamdarkness/godlytorch/Fragment/ThreeKnobFragment.kt
+++ b/app/src/main/java/com/teamdarkness/godlytorch/Fragment/ThreeKnobFragment.kt
@@ -83,7 +83,7 @@ class ThreeKnobFragment : Fragment(), OnFragmentBackPressListener {
             yellowLedFileLocation = prefs.getString(PREF_YELLOW_FILE_LOCATION, null)
             toggleFileLocation = prefs.getString(PREF_TOGGLE_FILE_LOCATION, null)
 
-            doubleTapEnabled = prefs.getBoolean(PREF_DOUBLE_TONE_ENABLED, false)
+            doubleTapEnabled = prefs.getBoolean(PREF_DOUBLE_TONE_ENABLED, true)
 
             // get max brightness
             brightnessMax = prefs.getInt("brightnessMax", 0)


### PR DESCRIPTION
Before this change, on first launch double tapping the knobs does nothing even though the settings switch is enabled, because the default preference value returned is false.

> The checkbox in Settings page is checked by default so the preference should return a default value of true

Also forced portrait orientation to prevent recreating MainActivity on rotation. As mentioned in commit message:

> Could be treated as a temporary fix if proper landscape support is planned, in which case onSaveInstanceState must be overridden in MainActivity