### PR TITLE
Fix LED file path for OnePlus One (bacon), proper device names for other OnePlus devices

### DIFF
--- a/app/src/main/java/com/teamdarkness/godlytorch/Utils/DeviceList.kt
+++ b/app/src/main/java/com/teamdarkness/godlytorch/Utils/DeviceList.kt
@@ -214,13 +214,13 @@ object DeviceList {
         )
         // Oneplus
         deviceList.add(
-                Device().setName("Oneplus One")
+                Device().setName("OnePlus One")
                         .setDeviceId("bacon")
                         .isDualTone(false)
-                        .setSingleLedFileLocation("torch-light0/brightness")
+                        .setSingleLedFileLocation("torch-light/brightness")
         )
         deviceList.add(
-                Device().setName("Oneplus 2")
+                Device().setName("OnePlus 2")
                         .setDeviceId("OnePlus2")
                         .isDualTone(true)
                         .setYellowLedFileLocation("led:torch_0/brightness")
@@ -228,7 +228,7 @@ object DeviceList {
                         .setToggleFileLocation("dummy")
         )
         deviceList.add(
-                Device().setName("Oneplus 3")
+                Device().setName("OnePlus 3")
                         .setDeviceId("oneplus3")
                         .isDualTone(true)
                         .setYellowLedFileLocation("led:torch_0/brightness")


### PR DESCRIPTION
This also fixes FC on launch on bacon (due to incorrect path)

Tested on OnePlus One running AOSP 8.1.0, Dot OS Nougat, and AEX 5.1 test build.