### PR TITLE
DeviceList: fixed mistype. capricon -> capricorn

### DIFF
--- a/app/src/main/java/com/teamdarkness/godlytorch/Utils/DeviceList.kt
+++ b/app/src/main/java/com/teamdarkness/godlytorch/Utils/DeviceList.kt
@@ -131,7 +131,7 @@ object DeviceList {
         )
         deviceList.add(
                 Device().setName("Mi 5s")
-                        .setDeviceId("capricon")
+                        .setDeviceId("capricorn")
                         .isDualTone(true)
                         .setYellowLedFileLocation("led:torch_0/brightness")
                         .setWhiteLedFileLocation("led:torch_1/brightness")


### PR DESCRIPTION
Without this fix the application can't automatically recognise the Xiaomi Mi 5s phone.

Signed-off-by: iamnotstanley <iamnotstanley@gmail.com>